### PR TITLE
Relocate Libs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gengetopt:
 	gengetopt --file-name=temper-hum-hid-cmd < temper-hum-hid-cmd.ggo
 
 $(TARGET): #gengetopt
-	$(CC) $(CFLAGS) $(INCLUDES) $(LIBS) temper-hum-hid-api.c temper-hum-hid-cmd.c temper-hum-hid.c -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) temper-hum-hid-api.c temper-hum-hid-cmd.c temper-hum-hid.c -o $@ $(LIBS)
 
 install:
 	cp temper-hum-hid /usr/bin/


### PR DESCRIPTION
This patch fixes the following compile error
(gcc version 4.8.1 (Ubuntu/Linaro 4.8.1-10ubuntu9)

/tmp/ccP4dNgw.o: In function `temperhum_close_devices':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:128: undefined reference to`libusb_release_interface'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:131: undefined reference to `libusb_attach_kernel_driver'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:135: undefined reference to`libusb_close'
/tmp/ccP4dNgw.o: In function `temperhum_init':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:164: undefined reference to`libusb_init'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:169: undefined reference to `libusb_set_debug'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:171: undefined reference to`libusb_set_debug'
/tmp/ccP4dNgw.o: In function `temperhum_close':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:189: undefined reference to`libusb_exit'
/tmp/ccP4dNgw.o: In function `temperhum_find':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:212: undefined reference to`libusb_get_device_list'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:224: undefined reference to `libusb_get_device_descriptor'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:230: undefined reference to`libusb_get_bus_number'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:231: undefined reference to `libusb_get_device_address'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:234: undefined reference to`libusb_get_active_config_descriptor'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:236: undefined reference to `libusb_get_config_descriptor'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:267: undefined reference to`libusb_open'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:275: undefined reference to `libusb_kernel_driver_active'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:278: undefined reference to`libusb_detach_kernel_driver'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:281: undefined reference to `libusb_close'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:287: undefined reference to`libusb_claim_interface'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:290: undefined reference to `libusb_close'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:305: undefined reference to`libusb_free_config_descriptor'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:308: undefined reference to `libusb_free_device_list'
/tmp/ccP4dNgw.o: In function`temperhum_reset_devices':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:332: undefined reference to `libusb_release_interface'
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:333: undefined reference to`libusb_reset_device'
/tmp/ccP4dNgw.o: In function `temperhum_send':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:358: undefined reference to`libusb_control_transfer'
/tmp/ccP4dNgw.o: In function `temperhum_recieve':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:388: undefined reference to`libusb_control_transfer'
/tmp/ccP4dNgw.o: In function `temperhum_fill':
/home/arnd/Projekte/kernel/temper-hum-hid/temper-hum-hid-api.c:706: undefined reference to`log'
collect2: error: ld returned 1 exit status

The gcc man page says: "[...] the placement of the -l option is significant."
